### PR TITLE
fix: multi platform exec

### DIFF
--- a/broz.js
+++ b/broz.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 'use strict'
-const { execFileSync } = require("child_process");
+const { execFileSync } = require('child_process')
 const path = require('path')
 
 const args = [path.resolve(__dirname, 'index.js'), process.argv[2] || '']
-execFileSync(String(require("electron")),args)
+execFileSync(String(require('electron')), args)

--- a/broz.js
+++ b/broz.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 'use strict'
-const execa = require('execa')
+const { execFileSync } = require("child_process");
 const path = require('path')
 
 const args = [path.resolve(__dirname, 'index.js'), process.argv[2] || '']
-execa.sync(String(require('electron')), args, { stdio: 'inherit' })
+execFileSync(String(require("electron")),args)


### PR DESCRIPTION
i dropped execa, in favor of native node.js child_process function.
also i have not tested it with macos... 

@antfu if you want to kep execa for macos, we would need to make wrapper similar in #2 to allow differnte logic for windows.