### PR TITLE
docs: fix macOS terminal exit keyboard shortcut

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ There is a hidden dragging area in the top left corner:
 
 You can do that by either:
 
-- End the process in Terminal by <kbd>⌘C</kbd> / <kbd>Ctrl</kbd>+<kbd>C</kbd>
+- End the process in Terminal by <kbd>^C</kbd> / <kbd>Ctrl</kbd>+<kbd>C</kbd>
 - Keyboard shortcuts <kbd>⌘W</kbd> / <kbd>⌘Q</kbd> / <kbd>Alt</kbd>+<kbd>F4</kbd>
 - Menu:
 ![](https://user-images.githubusercontent.com/11247099/116905572-bef5e500-ac71-11eb-9c10-2ebc7986adbd.png)


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<kbd>⌘C</kbd> copies text in macOS terminals, while <kbd>^C</kbd> sends SIGINT to the running process, causing it to exit.

<!-- e.g. is there anything you'd like reviewers to focus on? -->
