### PR TITLE
fix: initial width and height window options

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,8 +11,8 @@ const cli = cac('broz')
 cli
   .command('[url]', 'launch broz')
   .option('top', 'set window always on top')
-  .option('height', 'set initial window height')
-  .option('width', 'set initial window width')
+  .option('height <height>', 'set initial window height')
+  .option('width <width>', 'set initial window width')
   .option('frame', 'set window has a frame')
   .action(async (url, options) => {
     const args = {


### PR DESCRIPTION
### Description

Fixes window initial width and height options being interpreted as boolean values instead of numbers. This caused windows to fail displaying when initial dimensions were specified.

The fix ensures proper type handling for window configuration options, allowing users to set initial window dimensions without display issues.